### PR TITLE
`fonts-to-base64` auto-convert using less data-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gg-ukit",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "gg-ukit",
   "license": "MIT",
   "repository": "m-ruban/gg-ukit",

--- a/src/styles/fonts.less
+++ b/src/styles/fonts.less
@@ -5,7 +5,7 @@
     font-style: normal;
     font-weight: @basic-font-weight;
     font-display: swap;
-    src: url('./woff/cyrillic-ext.woff') format('woff');
+    src: data-uri('./woff/cyrillic-ext.woff') format('woff');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -14,7 +14,7 @@
     font-style: normal;
     font-weight: @basic-font-weight;
     font-display: swap;
-    src: url('./woff/cyrillic.woff') format('woff');
+    src: data-uri('./woff/cyrillic.woff') format('woff');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -23,7 +23,7 @@
     font-style: normal;
     font-weight: @basic-font-weight;
     font-display: swap;
-    src: url('./woff/latin-ext.woff') format('woff');
+    src: data-uri('./woff/latin-ext.woff') format('woff');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -32,7 +32,7 @@
     font-style: normal;
     font-weight: @basic-font-weight;
     font-display: swap;
-    src: url('./woff/latin.woff') format('woff');
+    src: data-uri('./woff/latin.woff') format('woff');
     // stylelint-disable-next-line
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
При первой загрузке страницы без кеша сначала отрисовывается дефолтный шрифт браузера, а когда подгружаются кастомные шрифты текст перерисовывается
Вариант решения: конвертировать шрифты в base64 напрямую в less

https://user-images.githubusercontent.com/70110788/212477378-313928ae-8863-417e-ad8e-2c3df3ef6b23.mov

